### PR TITLE
Implement basic models pipeline

### DIFF
--- a/models/DataPreprocessor.py
+++ b/models/DataPreprocessor.py
@@ -1,0 +1,66 @@
+"""Utilities for turning raw query plans into structured objects.
+
+The real project uses database specific JSON plans.  For the purpose of this
+skeleton repository we provide a tiny, generic representation so that other
+modules can operate on a predictable structure.  The :class:`DataPreprocessor`
+turns nested dictionaries that resemble PostgreSQL's ``EXPLAIN`` output into
+:class:`PlanNode` trees.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class PlanNode:
+    """A minimal tree node used throughout the modelling pipeline.
+
+    Parameters
+    ----------
+    node_type:
+        Name of the plan node, e.g. ``Seq Scan`` or ``Hash Join``.
+    children:
+        Child nodes in the execution plan tree.
+    extra_info:
+        Additional key/value pairs describing the node.  The preprocessor keeps
+        them untouched so that downstream components can decide what to use.
+    """
+
+    node_type: str
+    children: List["PlanNode"] = field(default_factory=list)
+    extra_info: Dict[str, Any] = field(default_factory=dict)
+
+
+class DataPreprocessor:
+    """Convert raw JSON style plans into :class:`PlanNode` trees."""
+
+    plan_key: str = "Plans"  # key that contains child nodes in the raw dict
+
+    def preprocess(self, plan: Dict[str, Any]) -> PlanNode:
+        """Recursively convert ``plan`` into a :class:`PlanNode` tree.
+
+        Parameters
+        ----------
+        plan:
+            JSON-like dictionary describing a plan node.  Nested plans are
+            expected under ``self.plan_key``.
+        """
+
+        node = PlanNode(
+            node_type=plan.get("Node Type", "Unknown"),
+            extra_info={k: v for k, v in plan.items() if k != self.plan_key},
+        )
+
+        for child in plan.get(self.plan_key, []):
+            node.children.append(self.preprocess(child))
+
+        return node
+
+    # Small convenience wrappers -------------------------------------------------
+
+    def preprocess_all(self, plans: Iterable[Dict[str, Any]]) -> List[PlanNode]:
+        """Preprocess a list of raw plans."""
+
+        return [self.preprocess(p) for p in plans]

--- a/models/Encoder.py
+++ b/models/Encoder.py
@@ -1,0 +1,61 @@
+"""Encode :class:`~models.DataPreprocessor.PlanNode` objects into vectors.
+
+The real project uses sophisticated graph neural networks.  Here we simply
+create a bag-of-node-types representation so that downstream components have a
+numeric vector to operate on.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+import numpy as np
+
+
+class Encoder:
+    """Naive encoder that assigns each node type a one-hot vector."""
+
+    def __init__(self) -> None:
+        self.node_index: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------ utilities
+    def _ensure_index(self, node_type: str) -> int:
+        if node_type not in self.node_index:
+            self.node_index[node_type] = len(self.node_index)
+        return self.node_index[node_type]
+
+    def _one_hot(self, idx: int) -> np.ndarray:
+        vec = np.zeros(len(self.node_index), dtype=float)
+        vec[idx] = 1.0
+        return vec
+
+    # --------------------------------------------------------------------- encoder
+    def encode(self, node) -> np.ndarray:
+        """Encode a single :class:`~models.DataPreprocessor.PlanNode`.
+
+        ``node`` is expected to expose ``node_type`` and ``children`` attributes
+        like the :class:`PlanNode` dataclass defined in :mod:`DataPreprocessor`.
+        The returned array has length equal to the number of unique node types
+        encountered so far.
+        """
+
+        idx = self._ensure_index(getattr(node, "node_type", "Unknown"))
+        vec = self._one_hot(idx)
+        if getattr(node, "children", None):
+            child_vecs = [self.encode(ch) for ch in node.children]
+            vec = self._pad_and_sum([vec] + child_vecs)
+        return vec
+
+    def encode_all(self, nodes: Iterable) -> List[np.ndarray]:
+        """Encode a list of nodes into vectors."""
+
+        return [self.encode(n) for n in nodes]
+
+    # ---------------------------------------------------------------- internal ---
+    def _pad_and_sum(self, vecs: List[np.ndarray]) -> np.ndarray:
+        """Pad vectors to equal length and return their sum."""
+
+        max_len = max(len(v) for v in vecs)
+        padded = np.zeros((len(vecs), max_len))
+        for i, v in enumerate(vecs):
+            padded[i, : len(v)] = v
+        return padded.sum(axis=0)

--- a/models/Gnto.py
+++ b/models/Gnto.py
@@ -1,0 +1,39 @@
+"""High level interface tying together the GNTO pipeline components."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .DataPreprocessor import DataPreprocessor
+from .Encoder import Encoder
+from .TreeModel import TreeModel
+from .Predictioner import Predictioner
+
+
+class GNTO:
+    """A minimal end-to-end pipeline.
+
+    The class wires the individual components so that ``run`` can be called with
+    a raw plan dictionary and returns a scalar prediction.  Each component can be
+    replaced by a custom implementation which mirrors how the full project is
+    expected to behave.
+    """
+
+    def __init__(self,
+                 preprocessor: DataPreprocessor | None = None,
+                 encoder: Encoder | None = None,
+                 tree_model: TreeModel | None = None,
+                 predictioner: Predictioner | None = None) -> None:
+        self.preprocessor = preprocessor or DataPreprocessor()
+        self.encoder = encoder or Encoder()
+        self.tree_model = tree_model or TreeModel()
+        self.predictioner = predictioner or Predictioner()
+
+    # ------------------------------------------------------------------ pipeline --
+    def run(self, plan: Dict[str, Any]) -> float:
+        """Execute the end-to-end pipeline on ``plan``."""
+
+        structured = self.preprocessor.preprocess(plan)
+        encoded = self.encoder.encode(structured)
+        vector = self.tree_model.forward([encoded])
+        return self.predictioner.predict(vector)

--- a/models/Predictioner.py
+++ b/models/Predictioner.py
@@ -1,0 +1,28 @@
+"""Prediction heads for GNTO.
+
+``Predictioner`` is intentionally lightweight.  It applies a linear model to the
+vector produced by :class:`TreeModel`.  The weights can either be provided
+explicitly or are initialised to ones.  The class stores the weights so it can
+be reused for multiple predictions.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+
+
+class Predictioner:
+    """A minimal linear prediction head."""
+
+    def __init__(self, weights: Iterable[float] | None = None) -> None:
+        self.weights = np.array(list(weights), dtype=float) if weights is not None else None
+
+    def predict(self, features: np.ndarray) -> float:
+        """Return a scalar prediction for ``features``."""
+
+        if self.weights is None:
+            self.weights = np.ones_like(features, dtype=float)
+        if len(self.weights) < len(features):
+            self.weights = np.pad(self.weights, (0, len(features) - len(self.weights)))
+        return float(np.dot(self.weights[: len(features)], features))

--- a/models/TreeModel.py
+++ b/models/TreeModel.py
@@ -1,0 +1,46 @@
+"""Simple tree aggregation model.
+
+The original project is expected to use complex neural network structures that
+operate on trees.  Here we provide a tiny, differentiable-free implementation
+that aggregates vectors produced by :class:`Encoder` into a single vector using a
+configurable reduction operation.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+
+
+class TreeModel:
+    """Aggregate encoded node vectors into a single representation."""
+
+    def __init__(self, reduction: str = "mean") -> None:
+        if reduction not in {"mean", "sum"}:
+            raise ValueError("reduction must be 'mean' or 'sum'")
+        self.reduction = reduction
+
+    def forward(self, vectors: Iterable[np.ndarray]) -> np.ndarray:
+        """Reduce ``vectors`` into a single vector.
+
+        Parameters
+        ----------
+        vectors:
+            Iterable of numpy arrays representing encoded plan nodes.
+        """
+
+        stacked = self._pad_and_stack(list(vectors))
+        if self.reduction == "mean":
+            return stacked.mean(axis=0)
+        return stacked.sum(axis=0)
+
+    # ------------------------------------------------------------------ helpers --
+    def _pad_and_stack(self, vecs: Iterable[np.ndarray]) -> np.ndarray:
+        vecs = list(vecs)
+        if not vecs:
+            return np.zeros(0)
+        max_len = max(len(v) for v in vecs)
+        stacked = np.zeros((len(vecs), max_len))
+        for i, v in enumerate(vecs):
+            stacked[i, : len(v)] = v
+        return stacked

--- a/models/Utils.py
+++ b/models/Utils.py
@@ -1,0 +1,28 @@
+"""Helper functions used across the GNTO models."""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable, List
+import numpy as np
+
+
+def set_seed(seed: int) -> None:
+    """Set random seeds for ``random`` and ``numpy``.
+
+    Deterministic behaviour is convenient when experimenting with different
+    model components.  This helper mirrors the behaviour of the real project in a
+    simplified form.
+    """
+
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+def flatten(nested: Iterable[Iterable]) -> List:
+    """Flatten a nested iterable into a list."""
+
+    out: List = []
+    for inner in nested:
+        out.extend(inner)
+    return out

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,22 @@
+"""Models package for the GNTO project.
+
+This package exposes a light‑weight but functional set of classes that mirror
+what a learning based query optimiser might require.  Each module is intentionally
+simple so that the repository remains easy to understand while still being
+executable.
+"""
+
+from .DataPreprocessor import DataPreprocessor, PlanNode
+from .Encoder import Encoder
+from .TreeModel import TreeModel
+from .Predictioner import Predictioner
+from .Gnto import GNTO
+
+__all__ = [
+    "DataPreprocessor",
+    "PlanNode",
+    "Encoder",
+    "TreeModel",
+    "Predictioner",
+    "GNTO",
+]


### PR DESCRIPTION
## Summary
- add dataclass-based `PlanNode` and `DataPreprocessor`
- implement naive one-hot `Encoder`, simple `TreeModel` aggregator, and linear `Predictioner`
- provide `GNTO` pipeline and helper utilities
- expose classes via `models.__init__`

## Testing
- `python -m py_compile models/*.py`
- `python - <<'PY' from models import GNTO; plan = {'Node Type': 'Seq Scan', 'Plans': [{'Node Type': 'Index Scan'}, {'Node Type': 'Seq Scan'}]}; model = GNTO(); print(model.run(plan)) PY`

------
https://chatgpt.com/codex/tasks/task_e_68aad594c878832ca2de2a0e844e0e1f