### PR TITLE
Integrate encoders with PyTorch base classes

### DIFF
--- a/models/Gnto.py
+++ b/models/Gnto.py
@@ -151,7 +151,11 @@ class GNTO:
             
             # Apply tree model aggregation
             vector = self.tree_model.forward(encoded_vectors)
-        
+
+        # Convert to numpy if tensor for prediction head
+        if hasattr(vector, 'detach'):
+            vector = vector.detach().cpu().numpy()
+
         # Make prediction
         return self.prediction_head.predict(vector)
     


### PR DESCRIPTION
## Summary
- make `NodeEncoder` inherit from `torch.nn.Module` and expose a `forward` method returning tensors
- convert simple `TreeEncoder` to `nn.Module` with optional torch/numpy backend
- ensure GNTO pipeline converts tensors to numpy for prediction
- require PyTorch for `NodeEncoder` and `TreeEncoder`, removing numpy fallbacks

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b13bccdd8c832cace81a03f9d81beb